### PR TITLE
Add steaming api to response back steps

### DIFF
--- a/flow-state/event/event.go
+++ b/flow-state/event/event.go
@@ -1,0 +1,34 @@
+package event
+
+import (
+	coreevent "github.com/project-flogo/core/engine/event"
+	"github.com/project-flogo/flow/state"
+	"time"
+)
+
+const EventType = "streamingStepEvent"
+
+type stepEvent struct {
+	time time.Time
+	step *state.Step
+}
+
+// Step retuns the step date
+func (re *stepEvent) Step() *state.Step {
+	return re.step
+}
+
+// Returns event time
+func (re *stepEvent) Time() time.Time {
+	return re.time
+}
+
+func PostStepEvent(step *state.Step) {
+	if coreevent.HasListener(EventType) {
+		fe := &stepEvent{
+			time: time.Now(),
+			step: step,
+		}
+		coreevent.Post(EventType, fe)
+	}
+}

--- a/flow-state/event/eventlistener.go
+++ b/flow-state/event/eventlistener.go
@@ -44,6 +44,7 @@ func handleRecordEvent() {
 					for checking := true; checking; {
 						if s != nil {
 							checking = false
+							break
 						}
 						recorderLog.Infof("Waiting for client step steaming connection")
 						time.Sleep(1 * time.Second)

--- a/flow-state/event/eventlistener.go
+++ b/flow-state/event/eventlistener.go
@@ -1,0 +1,99 @@
+package event
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/project-flogo/core/engine/event"
+	"github.com/project-flogo/core/support/log"
+	"github.com/project-flogo/flow/state"
+	"github.com/project-flogo/services/flow-state/stream"
+	"net/http"
+	"time"
+)
+
+var recorderLog = log.ChildLogger(log.RootLogger(), "step-listener")
+
+var stepEventQueue = make(chan *event.Context, 1)
+var done = make(chan bool, 1)
+var stepChan = make(chan *state.Step, 100)
+
+var s stream.EventStreamScheduler
+
+type recorderEvent struct {
+}
+
+func (ls *recorderEvent) HandleEvent(evt *event.Context) error {
+	stepEventQueue <- evt
+	return nil
+}
+
+func StartStepListener() {
+	err := event.RegisterListener("state-recorder-step-listener", &recorderEvent{}, []string{EventType})
+	if err != nil {
+		recorderLog.Errorf("Failed to enable state-recorder-step-listener due to error - '%v'", err)
+	}
+	go handleRecordEvent()
+}
+
+func handleRecordEvent() {
+	for {
+		select {
+		case stepE := <-stepEventQueue:
+			switch t := stepE.GetEvent().(type) {
+			case *stepEvent:
+				if s == nil {
+					for checking := true; checking; {
+						if s != nil {
+							checking = false
+						}
+						recorderLog.Infof("Waiting for client step steaming connection")
+						time.Sleep(1 * time.Second)
+					}
+					recorderLog.Infof("Client steaming steps connected")
+				}
+				step := t.Step()
+				if len(step.FlowChanges) > 0 {
+					//main flow
+					flowChange, ok := step.FlowChanges[0]
+					if ok && (flowChange.Status == 500 || flowChange.Status == 600 || flowChange.Status == 700) {
+						//Finish it after flow completed/canceled/failed
+						s.Finish(&stream.Response{Step: step, Status: stream.Completed})
+						done <- true
+					} else {
+						s.UpdateResponse(&stream.Response{Step: step, Status: stream.Running})
+					}
+				} else {
+					s.UpdateResponse(&stream.Response{Step: step, Status: stream.Running})
+				}
+			}
+		}
+	}
+}
+
+func setWriter(ss stream.EventStreamScheduler) {
+	s = ss
+}
+
+// Status is a basic health check for the server to determine if it is up
+func HandleStepEvent(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	connectionMonitor := stream.NewConnectionMonitor(make(chan int, 10))
+	if cn, ok := w.(http.CloseNotifier); ok {
+		// Listen to the closing of the http connection via the CloseNotifier
+		notify := cn.CloseNotify()
+		go func() {
+			<-notify
+			recorderLog.Info("Connection closed by the client or broken.")
+			connectionMonitor.ConnectionLost()
+		}()
+	}
+
+	s := stream.NewEventStreamScheduler(w, r, &stream.Response{Status: stream.Running, Details: "Waiting step data", Step: nil})
+	go func() {
+		// Start the scheduler
+		recorderLog.Debug("Starting connection monitor scheduler...")
+		s.Start(connectionMonitor)
+	}()
+
+	recorderLog.Info("Step streaming request comes")
+	setWriter(s)
+	<-done
+}

--- a/flow-state/server/rest/endpoints.go
+++ b/flow-state/server/rest/endpoints.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/project-flogo/services/flow-state/event"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -17,9 +18,10 @@ type ServiceEndpoints struct {
 	logger        log.Logger
 	stepStore     store.StepStore
 	snapshotStore store.SnapshotStore
+	streamingStep bool
 }
 
-func AppendEndpoints(router *httprouter.Router, logger log.Logger, exposeRecorder bool) {
+func AppendEndpoints(router *httprouter.Router, logger log.Logger, exposeRecorder bool, streamingStep bool) {
 
 	sm := &ServiceEndpoints{
 		logger:        logger,
@@ -32,6 +34,11 @@ func AppendEndpoints(router *httprouter.Router, logger log.Logger, exposeRecorde
 	router.GET("/v1/instances/:flowId/status", sm.getStatus)
 
 	router.GET("/v1/instances/:flowId/steps", sm.getSteps)
+	if streamingStep {
+		router.GET("/v1/stream/steps", event.HandleStepEvent)
+		event.StartStepListener()
+	}
+
 	router.GET("/v1/instances/:flowId/snapshot", sm.getSnapshot)
 	router.GET("/v1/instances/:flowId/snapshot/:stepId", sm.getSnapshotAtStep)
 	router.DELETE("/v1/instances/:flowId", sm.deleteInstance)

--- a/flow-state/store/mem/step.go
+++ b/flow-state/store/mem/step.go
@@ -1,14 +1,14 @@
 package mem
 
 import (
-	"sync"
-
 	"github.com/project-flogo/flow/state"
+	"github.com/project-flogo/services/flow-state/event"
 	"github.com/project-flogo/services/flow-state/store"
+	"sync"
 )
 
 func init() {
-	store.SetStepStore(&StepStore{stepContainers:make(map[string]*stepContainer)})
+	store.SetStepStore(&StepStore{stepContainers: make(map[string]*stepContainer)})
 }
 
 type StepStore struct {
@@ -36,7 +36,7 @@ func (s *StepStore) GetFlow(flowId string) *state.FlowInfo {
 	s.RUnlock()
 
 	if ok {
-		return &state.FlowInfo{Id: flowId, Status: sc.Status(), FlowURI:sc.flowURI}
+		return &state.FlowInfo{Id: flowId, Status: sc.Status(), FlowURI: sc.flowURI}
 	}
 
 	return nil
@@ -56,7 +56,7 @@ func (s *StepStore) GetFlows() []*state.FlowInfo {
 }
 
 func (s *StepStore) SaveStep(step *state.Step) error {
-
+	event.PostStepEvent(step)
 	s.RLock()
 	sc, ok := s.stepContainers[step.FlowId]
 	s.RUnlock()
@@ -95,9 +95,9 @@ func (s *StepStore) Delete(flowId string) {
 
 type stepContainer struct {
 	sync.RWMutex
-	status int
+	status  int
 	flowURI string
-	steps  []*state.Step
+	steps   []*state.Step
 }
 
 func (sc *stepContainer) Status() int {

--- a/flow-state/stream/connection.go
+++ b/flow-state/stream/connection.go
@@ -1,0 +1,38 @@
+package stream
+
+// Monitors and keeps the state of the current connection
+type ConnectionMonitor interface {
+	IsAlive() bool
+	ConnectionLost()
+}
+
+// The connection monitor
+type connectionMonitor struct {
+	ConnectionStateChannel chan int
+}
+
+var _ ConnectionMonitor = (*connectionMonitor)(nil)
+
+// Constructor for the ConnectionMonitor
+func NewConnectionMonitor(connectionStateChannel chan int) ConnectionMonitor {
+	return &connectionMonitor{ConnectionStateChannel: connectionStateChannel}
+}
+
+// Returns true if the connection still alive, or false otherwise
+func (monitor *connectionMonitor) IsAlive() bool {
+	var alive bool = true
+	// Try to write and read to the channel
+	defer func() {
+		if x := recover(); x != nil {
+			alive = false
+		}
+	}()
+	monitor.ConnectionStateChannel <- 1
+	<-monitor.ConnectionStateChannel
+	return alive
+}
+
+// Marks the connection as lost
+func (monitor *connectionMonitor) ConnectionLost() {
+	close(monitor.ConnectionStateChannel)
+}

--- a/flow-state/stream/scheduler.go
+++ b/flow-state/stream/scheduler.go
@@ -49,7 +49,7 @@ func NewEventStreamScheduler(w http.ResponseWriter, r *http.Request, defResponse
 		defaultResponse:          defResponse,
 		eventStreamChannel:       make(chan *Response),
 		schedulerFinishedChannel: make(chan int),
-		responseInterval:         1000,
+		responseInterval:         5000,
 		responseChannel:          make(chan *Response),
 	}
 }

--- a/flow-state/stream/scheduler.go
+++ b/flow-state/stream/scheduler.go
@@ -1,0 +1,173 @@
+package stream
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/project-flogo/flow/state"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+)
+
+//Response status
+const (
+	Failed    = "Failed"
+	Running   = "Running"
+	Completed = "Completed"
+)
+
+// Schedules the Server Side Event responses
+type EventStreamScheduler interface {
+	Start(ConnectionMonitor)
+	UpdateResponse(res *Response)
+	FinishWithError(errorDetails string)
+	Finish(res *Response)
+}
+
+// Schedules the event stream responses
+type eventStreamScheduler struct {
+	W                        http.ResponseWriter
+	R                        *http.Request
+	defaultResponse          *Response
+	eventStreamChannel       chan *Response
+	schedulerFinishedChannel chan int
+	responseInterval         int
+	responseChannel          chan *Response
+}
+
+type Response struct {
+	Status  string      `json:"status"`
+	Details string      `json:"details"`
+	Step    *state.Step `json:"step"`
+}
+
+// NewEventStreamScheduler create new Event Stream Scheduler
+func NewEventStreamScheduler(w http.ResponseWriter, r *http.Request, defResponse *Response) EventStreamScheduler {
+	return &eventStreamScheduler{
+		W:                        w,
+		R:                        r,
+		defaultResponse:          defResponse,
+		eventStreamChannel:       make(chan *Response),
+		schedulerFinishedChannel: make(chan int),
+		responseInterval:         1000,
+		responseChannel:          make(chan *Response),
+	}
+}
+
+// Start indicate to start the Event Stream Scheduler
+func (s *eventStreamScheduler) Start(connectionMonitor ConnectionMonitor) {
+	// Mark the end of the scheduler
+	defer func() {
+		s.schedulerFinishedChannel <- 1
+	}()
+
+	log.Info("Event Scheduler Started...")
+
+	s.W.Header().Set("Content-Type", "application/json")
+	s.W.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(s.W, "%s", "[")
+	// Write to the ResponseWriter, `w`.
+	json.NewEncoder(s.W).Encode(s.defaultResponse)
+
+	// Flush the response.  This is only possible if
+	// the response supports streaming.
+	if f, ok := s.W.(http.Flusher); ok {
+		log.WithFields(log.Fields{"response": s.defaultResponse}).Info("Sending Response: ")
+		f.Flush()
+	}
+
+	for building := true; building; {
+
+		select {
+		case res := <-s.eventStreamChannel:
+			if !connectionMonitor.IsAlive() {
+				// No connection so we should not write in response
+				log.Debug("Connection closed, stopping Event Stream Scheduler")
+				// Finishing build
+				building = false
+				break
+			}
+
+			// Print separator of json response
+			fmt.Fprintf(s.W, "%s", ",")
+			// Write to the ResponseWriter, `w`.
+			json.NewEncoder(s.W).Encode(res)
+			// Print end of json response
+			fmt.Fprintf(s.W, "%s", "]")
+
+			// Flush the response.  This is only possible if
+			// the response supports streaming.
+			if f, ok := s.W.(http.Flusher); ok {
+				log.WithFields(log.Fields{"response": res}).Debugf("Sending Response: ")
+				f.Flush()
+			}
+			building = false
+		case <-time.After(time.Millisecond * time.Duration(s.responseInterval)):
+			if !connectionMonitor.IsAlive() {
+				// No connection so we should not write in response
+				log.Debug("Connection closed, waiting for scheduler to stop")
+				// Finishing build
+				building = false
+				continue
+			}
+
+			// Print separator of json response
+			fmt.Fprintf(s.W, "%s", ",")
+			// Write to the ResponseWriter, `w`.
+			json.NewEncoder(s.W).Encode(s.defaultResponse)
+			// Flush the response.  This is only possible if
+			// the response supports streaming.
+			if f, ok := s.W.(http.Flusher); ok {
+				log.WithFields(log.Fields{
+					"response": s.defaultResponse,
+				}).Info("Sending Response: ")
+				f.Flush()
+			}
+
+		case res := <-s.responseChannel:
+			if !connectionMonitor.IsAlive() {
+				// No connection so we should not write in response
+				log.Debug("Connection closed, waiting for scheduler to stop")
+				// Finishing build
+				building = false
+				continue
+			}
+
+			// Print separator of json response
+			fmt.Fprintf(s.W, "%s", ",")
+			// Write to the ResponseWriter, `w`.
+			json.NewEncoder(s.W).Encode(res)
+			// Flush the response.  This is only possible if
+			// the response supports streaming.
+			if f, ok := s.W.(http.Flusher); ok {
+				log.WithFields(log.Fields{"response": s.defaultResponse}).Debugf("Sending Response: ")
+				f.Flush()
+			}
+		}
+	}
+
+}
+
+// UpdateResponse UpdateResponse indicate to update the response
+func (s *eventStreamScheduler) UpdateResponse(res *Response) {
+	s.responseChannel <- res
+}
+
+// FinishWithError indicate to complete the response with errors
+func (s *eventStreamScheduler) FinishWithError(errorDetails string) {
+	// Finish scheduler
+	s.Finish(&Response{
+		Status:  Failed,
+		Details: errorDetails,
+		Step:    nil,
+	})
+}
+
+// Finish indicate to complete the response
+func (s *eventStreamScheduler) Finish(res *Response) {
+	// Send response to the stream channel
+	s.eventStreamChannel <- res
+	// Wait for the scheduler to finish
+	<-s.schedulerFinishedChannel
+}


### PR DESCRIPTION
Fix #13 
1. Add an Event listener on Save steps.
2. Once listeners received events then we push back to streaming API.

The streaming API controlled by the service setting of `streamingStep `. the streaming-only be enabled when streamingStep set to true